### PR TITLE
feat: add interface `IReadOnlyBox<T>`

### DIFF
--- a/Dirt.Collections/IReadOnlyBox.cs
+++ b/Dirt.Collections/IReadOnlyBox.cs
@@ -1,0 +1,25 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace Dirt.Collections;
+
+/// <summary>
+/// A read-only Box provides a container that may or may not have a single value.
+/// </summary>
+/// <typeparam name="T">The type of the value stored in the box</typeparam>
+public interface IReadOnlyBox<out T> : IReadOnlyList<T>
+    where T : notnull
+{
+    /// <summary>
+    /// Returns true if the box is empty.
+    /// </summary>
+    [MemberNotNullWhen(false, nameof(Contents))]
+    bool IsEmpty { get; }
+
+    /// <summary>
+    /// Gets the current contents of the box. If the box is empty, an <see cref="InvalidOperationException"/> is thrown.
+    /// </summary>
+    /// <remarks>
+    /// This property has a nullable annotation to help ensure users check <see cref="IsEmpty"/> before accessing the contents.
+    /// </remarks>
+    T? Contents { get; }
+}


### PR DESCRIPTION
This interface will be used to represent a box that may or may not contain a value.

By accepting this interface (e.g. as a parameter to a method), it implies that you will not change the contents of the box (although you may mutate the value itself if it is mutable).

Implementations of this interface may still change the value inside the box.

Resolves: #5