### PR TITLE
feat: add interface `IImmutableBox<T>`

### DIFF
--- a/Dirt.Collections/Immutable/IImmutableBox.cs
+++ b/Dirt.Collections/Immutable/IImmutableBox.cs
@@ -1,0 +1,8 @@
+namespace Dirt.Collections.Immutable;
+
+/// <summary>
+/// A marker interface for a Box that cannot have its contents changed.
+/// </summary>
+/// <typeparam name="T">The type of the box contents.</typeparam>
+public interface IImmutableBox<out T> : IReadOnlyBox<T>
+    where T : notnull;


### PR DESCRIPTION
This interface will be used to mark box implementations that will not change their contents after they are created. Specifically:

- If a box is empty, it will stay empty
- The reference or value of a non-empty box will not change.

Note: if the type of the contents of the box is mutable, those operations may still occur.

Resolves: #7