### PR TITLE
feat: add DisposableStack and AsyncDisposableStack

### DIFF
--- a/Dirt.Collections.Tests/AsyncDisposableStackTests.cs
+++ b/Dirt.Collections.Tests/AsyncDisposableStackTests.cs
@@ -1,0 +1,225 @@
+namespace Dirt.Collections.Tests;
+
+public class AsyncDisposableStackTests
+{
+    [Fact]
+    public async Task Push_SingleAsyncDisposable_DisposesIt()
+    {
+        var disposable = new MockAsyncDisposable();
+
+        await using (var stack = new AsyncDisposableStack())
+        {
+            stack.Push(disposable);
+        }
+
+        Assert.True(disposable.Disposed);
+    }
+
+    [Fact]
+    public async Task Push_MultipleAsyncDisposables_DisposesInReverseOrder()
+    {
+        var disposables = new[]
+        {
+            new MockAsyncDisposable(),
+            new MockAsyncDisposable(),
+            new MockAsyncDisposable(),
+        };
+        var disposeOrder = new List<MockAsyncDisposable>();
+
+        foreach (var d in disposables)
+        {
+            d.DisposeAction = () => disposeOrder.Add(d);
+        }
+
+        await using (var stack = new AsyncDisposableStack())
+        {
+            foreach (var d in disposables)
+            {
+                stack.Push(d);
+            }
+        }
+
+        Assert.Equal(new[] { disposables[2], disposables[1], disposables[0] }, disposeOrder);
+    }
+
+    [Fact]
+    public async Task Push_SyncDisposable_WrapsAndDisposesIt()
+    {
+        var disposable = new MockDisposable();
+
+        await using (var stack = new AsyncDisposableStack())
+        {
+            stack.Push(disposable);
+        }
+
+        Assert.True(disposable.Disposed);
+    }
+
+    [Fact]
+    public async Task Push_SyncDisposable_WithAsyncInterface_UsesAsyncDirectly()
+    {
+        var disposable = new MockDualDisposable();
+
+        await using (var stack = new AsyncDisposableStack())
+        {
+            stack.Push((IDisposable)disposable);
+        }
+
+        Assert.True(disposable.AsyncDisposed);
+        Assert.False(disposable.SyncDisposed);
+    }
+
+    [Fact]
+    public async Task Push_MultipleDisposables_MixedTypes_DisposesInReverseOrder()
+    {
+        var asyncDisposable = new MockAsyncDisposable();
+        var syncDisposable = new MockDisposable();
+        var dualDisposable = new MockDualDisposable();
+
+        await using (var stack = new AsyncDisposableStack())
+        {
+            stack.Push(asyncDisposable);
+            stack.Push(syncDisposable);
+            stack.Push((IDisposable)dualDisposable);
+        }
+
+        Assert.True(asyncDisposable.Disposed);
+        Assert.True(syncDisposable.Disposed);
+        Assert.True(dualDisposable.AsyncDisposed);
+    }
+
+    [Fact]
+    public async Task DisposeAsync_MultipleDisposables_WithException_DisposesAllAndThrowsAggregate()
+    {
+        var disposables = new[]
+        {
+            new MockAsyncDisposable { ShouldThrow = true },
+            new MockAsyncDisposable(),
+            new MockAsyncDisposable { ShouldThrow = true },
+        };
+
+        await using var stack = new AsyncDisposableStack();
+        foreach (var d in disposables)
+        {
+            stack.Push(d);
+        }
+
+        var ex = await Assert.ThrowsAsync<AggregateException>(async () =>
+            await ((IAsyncDisposable)stack).DisposeAsync()
+        );
+
+        Assert.Equal(2, ex.InnerExceptions.Count);
+        foreach (var d in disposables)
+        {
+            Assert.True(d.Disposed);
+        }
+    }
+
+    [Fact]
+    public async Task DisposeAsync_CalledTwice_SecondCallDoesNothing()
+    {
+        var disposable = new MockAsyncDisposable();
+
+        var stack = new AsyncDisposableStack();
+        IAsyncDisposable d = stack;
+        stack.Push(disposable);
+
+        await d.DisposeAsync();
+        await d.DisposeAsync();
+
+        Assert.Equal(1, disposable.DisposeCount);
+    }
+
+    [Fact]
+    public async Task DisposeAsync_EmptyStack_DoesNotThrow()
+    {
+        await using var stack = new AsyncDisposableStack();
+    }
+
+    [Fact]
+    public void Push_AsyncDisposable_WithNull_ThrowsArgumentNullException()
+    {
+        var stack = new AsyncDisposableStack();
+
+        Assert.Throws<ArgumentNullException>(() => stack.Push((IAsyncDisposable)null!));
+    }
+
+    [Fact]
+    public void Push_Disposable_WithNull_ThrowsArgumentNullException()
+    {
+        var stack = new AsyncDisposableStack();
+
+        Assert.Throws<ArgumentNullException>(() => stack.Push((IDisposable)null!));
+    }
+
+    [Fact]
+    public async Task Push_AsyncDisposable_AfterDisposeAsync_Throws()
+    {
+        var disposable = new MockAsyncDisposable();
+        var stack = new AsyncDisposableStack();
+        IAsyncDisposable d = stack;
+        await d.DisposeAsync();
+        Assert.Throws<InvalidOperationException>(() => stack.Push(disposable));
+    }
+
+    [Fact]
+    public async Task Push_Disposable_AfterDisposeAsync_Throws()
+    {
+        var disposable = new MockDisposable();
+        var stack = new AsyncDisposableStack();
+        IAsyncDisposable d = stack;
+        await d.DisposeAsync();
+        Assert.Throws<InvalidOperationException>(() => stack.Push(disposable));
+    }
+
+    private sealed class MockDisposable : IDisposable
+    {
+        public bool Disposed { get; private set; }
+
+        public void Dispose()
+        {
+            Disposed = true;
+        }
+    }
+
+    private sealed class MockAsyncDisposable : IAsyncDisposable
+    {
+        public bool Disposed { get; private set; }
+        public int DisposeCount { get; private set; }
+        public bool ShouldThrow { get; init; }
+        public Action? DisposeAction { get; set; }
+
+        public async ValueTask DisposeAsync()
+        {
+            Disposed = true;
+            DisposeCount++;
+            DisposeAction?.Invoke();
+
+            if (ShouldThrow)
+            {
+                throw new TestException();
+            }
+
+            await ValueTask.CompletedTask;
+        }
+    }
+
+    private sealed class MockDualDisposable : IAsyncDisposable, IDisposable
+    {
+        public bool AsyncDisposed { get; private set; }
+        public bool SyncDisposed { get; private set; }
+
+        public void Dispose()
+        {
+            SyncDisposed = true;
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            AsyncDisposed = true;
+            await ValueTask.CompletedTask;
+        }
+    }
+
+    private sealed class TestException : Exception { }
+}

--- a/Dirt.Collections.Tests/DisposableStackTests.cs
+++ b/Dirt.Collections.Tests/DisposableStackTests.cs
@@ -1,0 +1,134 @@
+namespace Dirt.Collections.Tests;
+
+public class DisposableStackTests
+{
+    [Fact]
+    public void Push_SingleDisposable_DisposesIt()
+    {
+        var disposable = new MockDisposable();
+
+        using (var stack = new DisposableStack())
+        {
+            stack.Push(disposable);
+        }
+
+        Assert.True(disposable.Disposed);
+    }
+
+    [Fact]
+    public void Push_MultipleDisposables_DisposesInReverseOrder()
+    {
+        var disposables = new[]
+        {
+            new MockDisposable(),
+            new MockDisposable(),
+            new MockDisposable(),
+        };
+        var disposeOrder = new List<MockDisposable>();
+
+        foreach (var d in disposables)
+        {
+            d.DisposeAction = () => disposeOrder.Add(d);
+        }
+
+        using (var stack = new DisposableStack())
+        {
+            foreach (var d in disposables)
+            {
+                stack.Push(d);
+            }
+        }
+
+        Assert.Equal(new[] { disposables[2], disposables[1], disposables[0] }, disposeOrder);
+    }
+
+    [Fact]
+    public void Dispose_MultipleDisposables_WithException_DisposesAllAndThrowsAggregate()
+    {
+        var disposables = new[]
+        {
+            new MockDisposable { ShouldThrow = true },
+            new MockDisposable(),
+            new MockDisposable { ShouldThrow = true },
+        };
+
+        using var stack = new DisposableStack();
+        foreach (var d in disposables)
+        {
+            stack.Push(d);
+        }
+
+        var ex = Assert.Throws<AggregateException>(() => ((IDisposable)stack).Dispose());
+
+        Assert.Equal(2, ex.InnerExceptions.Count);
+        foreach (var d in disposables)
+        {
+            Assert.True(d.Disposed);
+        }
+    }
+
+    [Fact]
+    public void Dispose_CalledTwice_SecondCallDoesNothing()
+    {
+        var disposable = new MockDisposable();
+
+        var stack = new DisposableStack();
+        var d = (IDisposable)stack;
+        stack.Push(disposable);
+
+        // First dispose will dispose the pushed item
+        d.Dispose();
+
+        // Second dispose should be a no-op with respect to the item
+        d.Dispose();
+
+        Assert.True(disposable.Disposed);
+        Assert.Equal(1, disposable.DisposeCount);
+    }
+
+    [Fact]
+    public void Push_AfterDispose_Throws()
+    {
+        var disposable = new MockDisposable();
+        var stack = new DisposableStack();
+        var d = (IDisposable)stack;
+        d.Dispose();
+        Assert.Throws<InvalidOperationException>(() => stack.Push(disposable));
+    }
+
+    [Fact]
+    public void Dispose_EmptyStack_DoesNotThrow()
+    {
+        using var stack = new DisposableStack();
+    }
+
+    [Fact]
+    public void Push_WithNull_ThrowsArgumentNullException()
+    {
+        var stack = new DisposableStack();
+
+        Assert.Throws<ArgumentNullException>(() => stack.Push(null!));
+    }
+
+    private sealed class MockDisposable : IDisposable
+    {
+        public bool Disposed { get; private set; }
+        public int DisposeCount { get; private set; }
+        public bool ShouldThrow { get; init; }
+        public Action? DisposeAction { get; set; }
+
+        public void Dispose()
+        {
+            Disposed = true;
+            DisposeCount++;
+            DisposeAction?.Invoke();
+
+            if (ShouldThrow)
+            {
+                throw new TestException();
+            }
+        }
+    }
+
+    private sealed class TestException : Exception { }
+}

--- a/Dirt.Collections/AsyncDisposableStack.cs
+++ b/Dirt.Collections/AsyncDisposableStack.cs
@@ -1,0 +1,132 @@
+namespace Dirt.Collections;
+
+/// <summary>
+/// A stack-based collection for managing the asynchronous disposal of <see cref="IAsyncDisposable"/> objects.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The <see cref="AsyncDisposableStack"/> provides a convenient way to ensure that multiple asynchronously disposable objects
+/// are disposed in reverse order of their addition (LIFO - Last In, First Out). This is particularly useful
+/// when managing async resources that depend on each other and must be cleaned up in a specific order.
+/// </para>
+/// <para>
+/// The stack supports both <see cref="IAsyncDisposable"/> and <see cref="IDisposable"/> objects through overloaded
+/// <see cref="Push(IDisposable)"/> and <see cref="Push(IAsyncDisposable)"/> methods. Synchronous disposable objects are automatically wrapped to work with the async disposal pattern.
+/// </para>
+/// <para>
+/// When <see cref="IAsyncDisposable.DisposeAsync"/> is called, all objects in the stack are disposed asynchronously in reverse order of insertion.
+/// If any dispose operation throws an exception, all remaining objects are still disposed, and the exceptions
+/// are collected and thrown as an <see cref="AggregateException"/> after all disposal attempts.
+/// </para>
+/// </remarks>
+public sealed class AsyncDisposableStack : IAsyncDisposable
+{
+    private readonly Lock _sync = new();
+    private readonly Stack<IAsyncDisposable> _toDispose;
+    private bool _disposing;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AsyncDisposableStack"/> class.
+    /// </summary>
+    public AsyncDisposableStack()
+    {
+        _toDispose = new Stack<IAsyncDisposable>();
+    }
+
+    /// <summary>
+    /// Adds an asynchronously disposable object to the stack.
+    /// </summary>
+    /// <param name="disposable">The asynchronously disposable object to add to the stack.</param>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="disposable"/> is null.</exception>
+    /// <exception cref="InvalidOperationException">Thrown if the stack has already been disposed.</exception>
+    public void Push(IAsyncDisposable disposable)
+    {
+        ArgumentNullException.ThrowIfNull(disposable);
+        lock (_sync)
+        {
+            if (_disposing)
+            {
+                throw new InvalidOperationException(
+                    "Cannot re-use an AsyncDisposableStack after DisposeAsync."
+                );
+            }
+
+            _toDispose.Push(disposable);
+        }
+    }
+
+    /// <summary>
+    /// Adds a synchronously disposable object to the stack.
+    /// </summary>
+    /// <remarks>
+    /// If the object also implements <see cref="IAsyncDisposable"/>, the async version is used directly.
+    /// Otherwise, the synchronous disposable is automatically wrapped to work with the async disposal pattern.
+    /// </remarks>
+    /// <param name="disposable">The synchronously disposable object to add to the stack.</param>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="disposable"/> is null.</exception>
+    /// <exception cref="InvalidOperationException">Thrown if the stack has already been disposed.</exception>
+    public void Push(IDisposable disposable)
+    {
+        ArgumentNullException.ThrowIfNull(disposable);
+        if (disposable is IAsyncDisposable asyncDisposable)
+        {
+            Push(asyncDisposable);
+            return;
+        }
+        var wrapper = new DisposableWrapper(disposable);
+        Push(wrapper);
+    }
+
+    async ValueTask IAsyncDisposable.DisposeAsync()
+    {
+        List<IAsyncDisposable> pendingDisposal = [];
+        lock (_sync)
+        {
+            if (_disposing)
+            {
+                return;
+            }
+
+            _disposing = true;
+            while (_toDispose.TryPop(out var item))
+            {
+                pendingDisposal.Add(item);
+            }
+        }
+
+        var exceptions = new List<Exception>();
+
+        foreach (var item in pendingDisposal)
+        {
+            try
+            {
+                await item.DisposeAsync();
+            }
+            catch (Exception e)
+            {
+                exceptions.Add(e);
+            }
+        }
+
+        if (exceptions.Count > 0)
+        {
+            throw new AggregateException(exceptions);
+        }
+    }
+
+    sealed class DisposableWrapper(IDisposable toDispose) : IAsyncDisposable
+    {
+        private int _disposed;
+
+        ValueTask IAsyncDisposable.DisposeAsync()
+        {
+            if (Interlocked.Exchange(ref _disposed, 1) == 1)
+            {
+                return ValueTask.CompletedTask;
+            }
+
+            toDispose.Dispose();
+            return ValueTask.CompletedTask;
+        }
+    }
+}

--- a/Dirt.Collections/DisposableStack.cs
+++ b/Dirt.Collections/DisposableStack.cs
@@ -1,0 +1,76 @@
+namespace Dirt.Collections;
+
+/// <summary>
+/// A stack-based collection for managing the disposal of <see cref="IDisposable"/> objects.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The <see cref="DisposableStack"/> provides a convenient way to ensure that multiple disposable objects
+/// are disposed in reverse order of their addition (LIFO - Last In, First Out). This is particularly useful
+/// when managing resources that depend on each other and must be cleaned up in a specific order.
+/// </para>
+/// <para>
+/// When <see cref="IDisposable.Dispose"/> is called, all objects in the stack are disposed in reverse order of insertion.
+/// If any dispose operation throws an exception, all remaining objects are still disposed, and the exceptions
+/// are collected and thrown as an <see cref="AggregateException"/> after all disposal attempts.
+/// </para>
+/// </remarks>
+public sealed class DisposableStack : IDisposable
+{
+    private readonly Stack<IDisposable> _toDispose;
+    private bool _disposing;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DisposableStack"/> class.
+    /// </summary>
+    public DisposableStack()
+    {
+        _toDispose = new Stack<IDisposable>();
+    }
+
+    /// <summary>
+    /// Adds a disposable object to the stack.
+    /// </summary>
+    /// <param name="disposable">The disposable object to add to the stack.</param>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="disposable"/> is null.</exception>
+    /// <exception cref="InvalidOperationException">Thrown if the stack has already been disposed.</exception>
+    public void Push(IDisposable disposable)
+    {
+        ArgumentNullException.ThrowIfNull(disposable);
+        if (_disposing)
+        {
+            throw new InvalidOperationException("Cannot re-use a DisposableStack after Dispose.");
+        }
+
+        _toDispose.Push(disposable);
+    }
+
+    void IDisposable.Dispose()
+    {
+        if (_disposing)
+        {
+            return;
+        }
+
+        _disposing = true;
+
+        var exceptions = new List<Exception>();
+
+        while (_toDispose.TryPop(out var item))
+        {
+            try
+            {
+                item.Dispose();
+            }
+            catch (Exception e)
+            {
+                exceptions.Add(e);
+            }
+        }
+
+        if (exceptions.Count > 0)
+        {
+            throw new AggregateException(exceptions);
+        }
+    }
+}


### PR DESCRIPTION
These collection types can be used to accumulate a set of disposables to be all disposed in reverse-order when the stack is disposed.

Resolves: #4