### PR TITLE
Implement IEquatable for Box<T> and ImmutableBox

### DIFF
--- a/Dirt.Collections.Tests/BoxTests.cs
+++ b/Dirt.Collections.Tests/BoxTests.cs
@@ -1,4 +1,5 @@
 using System.Collections;
+using Dirt.Collections.Immutable;
 
 namespace Dirt.Collections.Tests;
 
@@ -151,5 +152,35 @@ public class BoxTests
         {
             box.SetContents(null!);
         });
+    }
+
+    [Fact]
+    public void TwoEmptyBoxes_Equal_True()
+    {
+        var box_one = Empty.Box<string>();
+        var box_two = Empty.Box<string>();
+
+        Assert.True(box_one.Equals(box_two));
+        Assert.Equal(box_one.GetHashCode(), box_two.GetHashCode());
+    }
+
+    [Fact]
+    public void SameContents_Equal_True()
+    {
+        var box_one = new Box<string>("initial value");
+        var box_two = new Box<string>("initial value");
+
+        Assert.True(box_one.Equals(box_two));
+        Assert.Equal(box_one.GetHashCode(), box_two.GetHashCode());
+    }
+
+    [Fact]
+    public void DifferentContents_Equal_False()
+    {
+        var box_one = new Box<string>("initial value");
+        var box_two = new Box<string>("initial value 2");
+
+        Assert.False(box_one.Equals(box_two));
+        Assert.NotEqual(box_one.GetHashCode(), box_two.GetHashCode());
     }
 }

--- a/Dirt.Collections/Box.cs
+++ b/Dirt.Collections/Box.cs
@@ -6,7 +6,7 @@ namespace Dirt.Collections;
 /// A Box provides a container for a single value. The box can also be empty.
 /// </summary>
 /// <typeparam name="T">The type of the value stored in the box.</typeparam>
-public sealed class Box<T> : IBox<T>, IReadOnlyBox<T>
+public sealed class Box<T> : IBox<T>, IReadOnlyBox<T>, IEquatable<IReadOnlyBox<T>>
     where T : notnull
 {
     /// <summary>
@@ -76,6 +76,30 @@ public sealed class Box<T> : IBox<T>, IReadOnlyBox<T>
     System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
     {
         return GetEnumerator();
+    }
+
+    public bool Equals(IReadOnlyBox<T>? other)
+    {
+        if (other is null)
+            return false;
+
+        if (other.IsEmpty && IsEmpty)
+            return true;
+
+        if (other.IsEmpty || IsEmpty)
+            return false;
+
+        return EqualityComparer<T>.Default.Equals(Contents, other[0]);
+    }
+
+    public override bool Equals(object? obj)
+    {
+        return obj is IReadOnlyBox<T> other && Equals(other);
+    }
+
+    public override int GetHashCode()
+    {
+        return IsEmpty ? 0 : EqualityComparer<T>.Default.GetHashCode(Contents);
     }
 }
 


### PR DESCRIPTION
Implements `IEquatable<IReadOnlyBox<T>>` for `Box<T>` to support value-based equality.

- Empty boxes equal other empty boxes
- Boxes with same contents are equal
- Added equality tests